### PR TITLE
Update Doorbell.m

### DIFF
--- a/Classes/Doorbell.m
+++ b/Classes/Doorbell.m
@@ -1,7 +1,7 @@
 #import "Doorbell.h"
 #import "DoorbellDialog.h"
 
-NSString * const EndpointTemplate = @"https://doorbell.io/api/applications/%@/%@?sdk=ios&version=0.1.0&key=%@";
+NSString * const EndpointTemplate = @"https://doorbell.io/api/applications/%@/%@?sdk=ios&version=0.1.1&key=%@";
 NSString * const UserAgent = @"Doorbell iOS SDK";
 
 @interface Doorbell () <DoorbellDialogDelegate>


### PR DESCRIPTION
Fixed outdated SDK version number (triggers a warning in the dashboard, saying that you're not using the latest SDK).